### PR TITLE
fix: HTMLファイルとProfileコンポーネントの画像パス・メタタグ修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,12 +10,14 @@
     <meta property="og:title" content="Kuwaharu's Portfolio">
     <meta property="og:type" content="website">
     <meta property="og:description" content="システムエンジニアを目指す学生のポートフォリオ">
-    <meta property="og:image" content="https://www.kuwaharu.com/thumbnail.png">
-    <meta property="og:url" content="https://www.kuwaharu.com">
+    <meta property="og:image" content="https://kuwaharu-git.github.io/my-portfolio/thumbnail.png">
+    <meta property="og:url" content="https://kuwaharu-git.github.io/my-portfolio/">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Kuwaharu's Portfolio">
     <meta name="twitter:description" content="システムエンジニアを目指す学生のポートフォリオ">
-    <meta name="twitter:image" content="https://www.kuwaharu.com/thumbnail.png">
+    <meta name="twitter:image" content="https://kuwaharu-git.github.io/my-portfolio/thumbnail.png">
+    <link rel="icon" type="image/svg+xml" href="/my-portfolio/icon.svg">
+    <link rel="apple-touch-icon" href="/my-portfolio/icon.png">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css">
     <title>kuwaharu-Portfolio</title>
     <!-- google-fontsからフォントを読み込む -->

--- a/public/404.html
+++ b/public/404.html
@@ -10,12 +10,14 @@
     <meta property="og:title" content="Kuwaharu's Portfolio">
     <meta property="og:type" content="website">
     <meta property="og:description" content="システムエンジニアを目指す学生のポートフォリオ">
-    <meta property="og:image" content="https://www.kuwaharu.com/thumbnail.png">
-    <meta property="og:url" content="https://www.kuwaharu.com">
+    <meta property="og:image" content="https://kuwaharu-git.github.io/my-portfolio/thumbnail.png">
+    <meta property="og:url" content="https://kuwaharu-git.github.io/my-portfolio/">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Kuwaharu's Portfolio">
     <meta name="twitter:description" content="システムエンジニアを目指す学生のポートフォリオ">
-    <meta name="twitter:image" content="https://www.kuwaharu.com/thumbnail.png">
+    <meta name="twitter:image" content="https://kuwaharu-git.github.io/my-portfolio/thumbnail.png">
+    <link rel="icon" type="image/svg+xml" href="/my-portfolio/icon.svg">
+    <link rel="apple-touch-icon" href="/my-portfolio/icon.png">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css">
     <title>kuwaharu-Portfolio</title>
     <!-- google-fontsからフォントを読み込む -->

--- a/src/components/Index/Profile.jsx
+++ b/src/components/Index/Profile.jsx
@@ -1,13 +1,14 @@
 /** @jsxImportSource @emotion/react */
 import styled from '@emotion/styled';
 import breakpoints from '../../breakpoints';
+import { getImagePath } from '../../utils/paths';
 
 export const Profile = () => {
     return (
         <ProfileWrapper id='profile'>
             <Title>About me</Title>
             <Contents>
-                <ImageIcon src='/icon.svg' alt='icon image'></ImageIcon>
+                <ImageIcon src={getImagePath('/icon.svg')} alt='icon image'></ImageIcon>
                 <Sentence>システムエンジニアになるために色々勉強中の学生です。主に使用している言語はPythonで、Fast APIやDjangoを使用したバックエンド開発、ドローンの自立飛行、OR-Toolsを使用したシフト自動作成など色々チャレンジしています。他にもReactを使用したフロントエンド開発、LinuxやAWSなどのインフラ系なども学習しています。</Sentence>
             </Contents>
             <SnsUl>


### PR DESCRIPTION
- index.html, 404.htmlのOG画像、Twitter画像URLを新URLに更新
- favicon設定を追加
- ProfileコンポーネントのアイコンでgetImagePath関数を使用
- GitHub Pagesでの画像表示とメタタグ対応を完了